### PR TITLE
feat: Add past versions dropdown to navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -17,6 +17,14 @@
                 <li><a href="testimonials.html">Testimonials</a></li>
                 <li><a href="blog.html">Blog</a></li>
                 <li><a href="contact.html">Contact Us</a></li>
+                <li class="dropdown">
+                    <a href="javascript:void(0)" class="dropbtn">Past Versions</a>
+                    <div class="dropdown-content">
+                        <a href="version-2020/index.html">2020 Version</a>
+                        <a href="version-2016/index.html">2016 Version</a>
+                        <a href="version-2015/index.html">2015 Version</a>
+                    </div>
+                </li>
             </ul>
         </nav>
     </header>

--- a/appeals.html
+++ b/appeals.html
@@ -17,6 +17,14 @@
                 <li><a href="testimonials.html">Testimonials</a></li>
                 <li><a href="blog.html">Blog</a></li>
                 <li><a href="contact.html">Contact Us</a></li>
+                <li class="dropdown">
+                    <a href="javascript:void(0)" class="dropbtn">Past Versions</a>
+                    <div class="dropdown-content">
+                        <a href="version-2020/index.html">2020 Version</a>
+                        <a href="version-2016/index.html">2016 Version</a>
+                        <a href="version-2015/index.html">2015 Version</a>
+                    </div>
+                </li>
             </ul>
         </nav>
     </header>

--- a/blog.html
+++ b/blog.html
@@ -17,6 +17,14 @@
                 <li><a href="testimonials.html">Testimonials</a></li>
                 <li><a href="blog.html">Blog</a></li>
                 <li><a href="contact.html">Contact Us</a></li>
+                <li class="dropdown">
+                    <a href="javascript:void(0)" class="dropbtn">Past Versions</a>
+                    <div class="dropdown-content">
+                        <a href="version-2020/index.html">2020 Version</a>
+                        <a href="version-2016/index.html">2016 Version</a>
+                        <a href="version-2015/index.html">2015 Version</a>
+                    </div>
+                </li>
             </ul>
         </nav>
     </header>

--- a/contact.html
+++ b/contact.html
@@ -17,6 +17,14 @@
                 <li><a href="testimonials.html">Testimonials</a></li>
                 <li><a href="blog.html">Blog</a></li>
                 <li><a href="contact.html">Contact Us</a></li>
+                <li class="dropdown">
+                    <a href="javascript:void(0)" class="dropbtn">Past Versions</a>
+                    <div class="dropdown-content">
+                        <a href="version-2020/index.html">2020 Version</a>
+                        <a href="version-2016/index.html">2016 Version</a>
+                        <a href="version-2015/index.html">2015 Version</a>
+                    </div>
+                </li>
             </ul>
         </nav>
     </header>

--- a/css/style.css
+++ b/css/style.css
@@ -89,3 +89,46 @@ footer {
     background: #333;
     color: #fff;
 }
+
+/* Dropdown Button */
+.dropbtn {
+  padding: 0;
+  font-size: 16px;
+  border: none;
+  cursor: pointer;
+  background: #333;
+  color: #fff;
+  font-family: sans-serif;
+}
+
+/* The container <div> - needed to position the dropdown content */
+.dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+/* Dropdown Content (Hidden by Default) */
+.dropdown-content {
+  display: none;
+  position: absolute;
+  background-color: #f9f9f9;
+  min-width: 160px;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  z-index: 1;
+}
+
+/* Links inside the dropdown */
+.dropdown-content a {
+  color: black;
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+}
+
+/* Change color of dropdown links on hover */
+.dropdown-content a:hover {background-color: #f1f1f1}
+
+/* Show the dropdown menu on hover */
+.dropdown:hover .dropdown-content {
+  display: block;
+}

--- a/index.html
+++ b/index.html
@@ -17,6 +17,14 @@
                 <li><a href="testimonials.html">Testimonials</a></li>
                 <li><a href="blog.html">Blog</a></li>
                 <li><a href="contact.html">Contact Us</a></li>
+                <li class="dropdown">
+                    <a href="javascript:void(0)" class="dropbtn">Past Versions</a>
+                    <div class="dropdown-content">
+                        <a href="version-2020/index.html">2020 Version</a>
+                        <a href="version-2016/index.html">2016 Version</a>
+                        <a href="version-2015/index.html">2015 Version</a>
+                    </div>
+                </li>
             </ul>
         </nav>
     </header>

--- a/testimonials.html
+++ b/testimonials.html
@@ -17,6 +17,14 @@
                 <li><a href="testimonials.html">Testimonials</a></li>
                 <li><a href="blog.html">Blog</a></li>
                 <li><a href="contact.html">Contact Us</a></li>
+                <li class="dropdown">
+                    <a href="javascript:void(0)" class="dropbtn">Past Versions</a>
+                    <div class="dropdown-content">
+                        <a href="version-2020/index.html">2020 Version</a>
+                        <a href="version-2016/index.html">2016 Version</a>
+                        <a href="version-2015/index.html">2015 Version</a>
+                    </div>
+                </li>
             </ul>
         </nav>
     </header>


### PR DESCRIPTION
Adds a dropdown menu to the main navigation bar that provides links to past versions of the website (2015, 2016, and 2020).

This change involves:
- Adding the HTML for the dropdown to all pages to ensure consistent navigation.
- Adding CSS to style the dropdown and implement hover-to-open functionality.