### PR TITLE
Scrape SEO details from all site versions

### DIFF
--- a/SEO/combined_seo_report.csv
+++ b/SEO/combined_seo_report.csv
@@ -1,0 +1,404 @@
+Version,SEO_Element,Value
+version-2016,File Path,version-2016/index.html
+version-2016,Title,Law4Veterans - 2016 Version
+version-2016,Meta Description,Not Found
+version-2016,Meta Keywords,Not Found
+version-2016,Meta Author,Not Found
+version-2016,Meta Viewport,"width=device-width, initial-scale=1.0"
+version-2016,Meta Robots,Not Found
+version-2016,Canonical URL,Not Found
+version-2016,h2_1,Denied Benefits?
+version-2016,h2_2,Locked Out of Benefits?
+version-2016,h2_3,Contact Us TODAY!
+version-2016,Image Alt_1,Law4Veterans Logo
+version-2016,Link_1,#
+version-2016,Link_2,#
+version-2016,Link_3,#
+version-2016,Link_4,#
+version-2016,Link_5,#
+version-2016,Link_6,#
+version-2016,Link_7,#
+version-2016,Language,en
+version-2016,---,---
+version-2016,File Path,version-2016/scraped_content.html
+version-2016,Title,Not Found
+version-2016,Meta Description,Not Found
+version-2016,Meta Keywords,Not Found
+version-2016,Meta Author,Not Found
+version-2016,Meta Viewport,Not Found
+version-2016,Meta Robots,Not Found
+version-2016,Canonical URL,Not Found
+version-2016,Language,Not Found
+version-2016,---,---
+current_version,File Path,./testimonials.html
+current_version,Title,Testimonials - Law4Veterans
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,"width=device-width, initial-scale=1.0"
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,h1_1,Law4Veterans
+current_version,h2_1,What Vets Say about Us
+current_version,Link_1,index.html
+current_version,Link_2,about.html
+current_version,Link_3,appeals.html
+current_version,Link_4,testimonials.html
+current_version,Link_5,blog.html
+current_version,Link_6,contact.html
+current_version,Link_7,javascript:void(0)
+current_version,Link_8,version-2020/index.html
+current_version,Link_9,version-2016/index.html
+current_version,Link_10,version-2015/index.html
+current_version,Language,en
+current_version,---,---
+current_version,File Path,./contact.html
+current_version,Title,Contact Us - Law4Veterans
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,"width=device-width, initial-scale=1.0"
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,h1_1,Law4Veterans
+current_version,h2_1,Contact Law4Veterans
+current_version,h3_1,Contact Law4Veterans
+current_version,Link_1,index.html
+current_version,Link_2,about.html
+current_version,Link_3,appeals.html
+current_version,Link_4,testimonials.html
+current_version,Link_5,blog.html
+current_version,Link_6,contact.html
+current_version,Link_7,javascript:void(0)
+current_version,Link_8,version-2020/index.html
+current_version,Link_9,version-2016/index.html
+current_version,Link_10,version-2015/index.html
+current_version,Link_11,mailto:joe@law4veterans.com
+current_version,Language,en
+current_version,---,---
+current_version,File Path,./about.html
+current_version,Title,About Us - Law4Veterans
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,"width=device-width, initial-scale=1.0"
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,h1_1,Law4Veterans
+current_version,h2_1,Our Commitment
+current_version,h3_1,Nationwide. Veterans. Lawyers.
+current_version,Link_1,index.html
+current_version,Link_2,about.html
+current_version,Link_3,appeals.html
+current_version,Link_4,testimonials.html
+current_version,Link_5,blog.html
+current_version,Link_6,contact.html
+current_version,Link_7,javascript:void(0)
+current_version,Link_8,version-2020/index.html
+current_version,Link_9,version-2016/index.html
+current_version,Link_10,version-2015/index.html
+current_version,Link_11,contact.html
+current_version,Language,en
+current_version,---,---
+current_version,File Path,./index.html
+current_version,Title,Law4Veterans
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,"width=device-width, initial-scale=1.0"
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,h1_1,Law4Veterans
+current_version,h2_1,Have You Been Denied a VA Benefits Claim?
+current_version,h2_2,Have You Been Denied Veterans Disability Benefits?
+current_version,h2_3,Do You Feel like You’re Locked Out of Your Benefits?
+current_version,h2_4,Post Traumatic Stress Disorder (PTSD)
+current_version,h2_5,PACT ACT
+current_version,h2_6,Burn Pit Exposure
+current_version,h2_7,Military Sexual Trauma/Military Assault
+current_version,h2_8,Orthopedic Injuries
+current_version,h2_9,Chronic Diseases Acquired while in service
+current_version,h2_10,Vaccine Injuries
+current_version,h2_11,Toxic Chemical Exposure/Agent Orange/Radiation
+current_version,h3_1,What does it mean to have a presumptive condition for toxic exposure?
+current_version,h3_2,These cancers are now presumptive:
+current_version,h3_3,These illnesses are now presumptive:
+current_version,Link_1,index.html
+current_version,Link_2,about.html
+current_version,Link_3,appeals.html
+current_version,Link_4,testimonials.html
+current_version,Link_5,blog.html
+current_version,Link_6,contact.html
+current_version,Link_7,javascript:void(0)
+current_version,Link_8,version-2020/index.html
+current_version,Link_9,version-2016/index.html
+current_version,Link_10,version-2015/index.html
+current_version,Link_11,contact.html
+current_version,Link_12,testimonials.html
+current_version,Link_13,about.html
+current_version,Language,en
+current_version,---,---
+current_version,File Path,./blog.html
+current_version,Title,Blog - Law4Veterans
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,"width=device-width, initial-scale=1.0"
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,h1_1,Law4Veterans
+current_version,h2_1,Blog
+current_version,h3_1,Board of Veteran’s Appeals
+current_version,Link_1,index.html
+current_version,Link_2,about.html
+current_version,Link_3,appeals.html
+current_version,Link_4,testimonials.html
+current_version,Link_5,blog.html
+current_version,Link_6,contact.html
+current_version,Link_7,javascript:void(0)
+current_version,Link_8,version-2020/index.html
+current_version,Link_9,version-2016/index.html
+current_version,Link_10,version-2015/index.html
+current_version,Link_11,#
+current_version,Language,en
+current_version,---,---
+current_version,File Path,./appeals.html
+current_version,Title,Help with Appeals - Law4Veterans
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,"width=device-width, initial-scale=1.0"
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,h1_1,Law4Veterans
+current_version,h2_1,Help With Appeals
+current_version,h3_1,Help With Appeals
+current_version,Link_1,index.html
+current_version,Link_2,about.html
+current_version,Link_3,appeals.html
+current_version,Link_4,testimonials.html
+current_version,Link_5,blog.html
+current_version,Link_6,contact.html
+current_version,Link_7,javascript:void(0)
+current_version,Link_8,version-2020/index.html
+current_version,Link_9,version-2016/index.html
+current_version,Link_10,version-2015/index.html
+current_version,Language,en
+current_version,---,---
+current_version,File Path,./version-2020/index.html
+current_version,Title,Law4Veterans - 2020 Version
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,"width=device-width, initial-scale=1.0"
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,h1_1,Have You Been Denied a VA Benefits Claim?
+current_version,h2_1,Have you been denied Veterans Disability Benefits?
+current_version,h2_2,Do you Feel Like You’re Locked Out of your benefits?
+current_version,h2_3,Call Today to Schedule your FREE Consultation
+current_version,h3_1,"Bochicchio & Pennebaker, PLLC"
+current_version,Link_1,#
+current_version,Link_2,#
+current_version,Link_3,#
+current_version,Link_4,#
+current_version,Link_5,#
+current_version,Link_6,#
+current_version,Link_7,#
+current_version,Link_8,#
+current_version,Link_9,#
+current_version,Language,en
+current_version,---,---
+current_version,File Path,./version-2020/scraped_content.html
+current_version,Title,Not Found
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,Not Found
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,Language,Not Found
+current_version,---,---
+current_version,File Path,./version-2015/index.html
+current_version,Title,Law4Veterans - 2015 Version
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,"width=device-width, initial-scale=1.0"
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,h1_1,DENIED VA BENEFITS?
+current_version,h2_1,"Joseph M Bochicchio, PLLC"
+current_version,h2_2,Denied Veterans Disability Benefits?
+current_version,h2_3,"Feel Like You're ""Locked Out"" of Your Benefits?"
+current_version,h3_1,Law 4 Veterans
+current_version,Link_1,#
+current_version,Link_2,#
+current_version,Link_3,#
+current_version,Link_4,#
+current_version,Language,en
+current_version,---,---
+current_version,File Path,./version-2015/scraped_content.html
+current_version,Title,Not Found
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,Not Found
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,Language,Not Found
+current_version,---,---
+current_version,File Path,./version-2016/index.html
+current_version,Title,Law4Veterans - 2016 Version
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,"width=device-width, initial-scale=1.0"
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,h2_1,Denied Benefits?
+current_version,h2_2,Locked Out of Benefits?
+current_version,h2_3,Contact Us TODAY!
+current_version,Image Alt_1,Law4Veterans Logo
+current_version,Link_1,#
+current_version,Link_2,#
+current_version,Link_3,#
+current_version,Link_4,#
+current_version,Link_5,#
+current_version,Link_6,#
+current_version,Link_7,#
+current_version,Language,en
+current_version,---,---
+current_version,File Path,./version-2016/scraped_content.html
+current_version,Title,Not Found
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,Not Found
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,Language,Not Found
+current_version,---,---
+current_version,File Path,./scraped_content/20240820140802_index.html
+current_version,Title,Not Found
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,Not Found
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,Language,Not Found
+current_version,---,---
+current_version,File Path,./scraped_content/20240820140802_blog.html
+current_version,Title,Not Found
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,Not Found
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,Language,Not Found
+current_version,---,---
+current_version,File Path,./scraped_content/20240820140802_about-us.html
+current_version,Title,Not Found
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,Not Found
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,Language,Not Found
+current_version,---,---
+current_version,File Path,./scraped_content/20240820140802_what-vets-say-about-us.html
+current_version,Title,Not Found
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,Not Found
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,Language,Not Found
+current_version,---,---
+current_version,File Path,./scraped_content/20240820140802_help-with-appeals.html
+current_version,Title,Not Found
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,Not Found
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,Language,Not Found
+current_version,---,---
+current_version,File Path,./scraped_content/20240820140802_contact-us.html
+current_version,Title,Not Found
+current_version,Meta Description,Not Found
+current_version,Meta Keywords,Not Found
+current_version,Meta Author,Not Found
+current_version,Meta Viewport,Not Found
+current_version,Meta Robots,Not Found
+current_version,Canonical URL,Not Found
+current_version,Language,Not Found
+current_version,---,---
+version-2015,File Path,version-2015/index.html
+version-2015,Title,Law4Veterans - 2015 Version
+version-2015,Meta Description,Not Found
+version-2015,Meta Keywords,Not Found
+version-2015,Meta Author,Not Found
+version-2015,Meta Viewport,"width=device-width, initial-scale=1.0"
+version-2015,Meta Robots,Not Found
+version-2015,Canonical URL,Not Found
+version-2015,h1_1,DENIED VA BENEFITS?
+version-2015,h2_1,"Joseph M Bochicchio, PLLC"
+version-2015,h2_2,Denied Veterans Disability Benefits?
+version-2015,h2_3,"Feel Like You're ""Locked Out"" of Your Benefits?"
+version-2015,h3_1,Law 4 Veterans
+version-2015,Link_1,#
+version-2015,Link_2,#
+version-2015,Link_3,#
+version-2015,Link_4,#
+version-2015,Language,en
+version-2015,---,---
+version-2015,File Path,version-2015/scraped_content.html
+version-2015,Title,Not Found
+version-2015,Meta Description,Not Found
+version-2015,Meta Keywords,Not Found
+version-2015,Meta Author,Not Found
+version-2015,Meta Viewport,Not Found
+version-2015,Meta Robots,Not Found
+version-2015,Canonical URL,Not Found
+version-2015,Language,Not Found
+version-2015,---,---
+version-2020,File Path,version-2020/index.html
+version-2020,Title,Law4Veterans - 2020 Version
+version-2020,Meta Description,Not Found
+version-2020,Meta Keywords,Not Found
+version-2020,Meta Author,Not Found
+version-2020,Meta Viewport,"width=device-width, initial-scale=1.0"
+version-2020,Meta Robots,Not Found
+version-2020,Canonical URL,Not Found
+version-2020,h1_1,Have You Been Denied a VA Benefits Claim?
+version-2020,h2_1,Have you been denied Veterans Disability Benefits?
+version-2020,h2_2,Do you Feel Like You’re Locked Out of your benefits?
+version-2020,h2_3,Call Today to Schedule your FREE Consultation
+version-2020,h3_1,"Bochicchio & Pennebaker, PLLC"
+version-2020,Link_1,#
+version-2020,Link_2,#
+version-2020,Link_3,#
+version-2020,Link_4,#
+version-2020,Link_5,#
+version-2020,Link_6,#
+version-2020,Link_7,#
+version-2020,Link_8,#
+version-2020,Link_9,#
+version-2020,Language,en
+version-2020,---,---
+version-2020,File Path,version-2020/scraped_content.html
+version-2020,Title,Not Found
+version-2020,Meta Description,Not Found
+version-2020,Meta Keywords,Not Found
+version-2020,Meta Author,Not Found
+version-2020,Meta Viewport,Not Found
+version-2020,Meta Robots,Not Found
+version-2020,Canonical URL,Not Found
+version-2020,Language,Not Found
+version-2020,---,---

--- a/SEO/current_version_seo.csv
+++ b/SEO/current_version_seo.csv
@@ -1,0 +1,310 @@
+SEO_Element,Value
+File Path,./testimonials.html
+Title,Testimonials - Law4Veterans
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,"width=device-width, initial-scale=1.0"
+Meta Robots,Not Found
+Canonical URL,Not Found
+h1_1,Law4Veterans
+h2_1,What Vets Say about Us
+Link_1,index.html
+Link_2,about.html
+Link_3,appeals.html
+Link_4,testimonials.html
+Link_5,blog.html
+Link_6,contact.html
+Link_7,javascript:void(0)
+Link_8,version-2020/index.html
+Link_9,version-2016/index.html
+Link_10,version-2015/index.html
+Language,en
+---,---
+File Path,./contact.html
+Title,Contact Us - Law4Veterans
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,"width=device-width, initial-scale=1.0"
+Meta Robots,Not Found
+Canonical URL,Not Found
+h1_1,Law4Veterans
+h2_1,Contact Law4Veterans
+h3_1,Contact Law4Veterans
+Link_1,index.html
+Link_2,about.html
+Link_3,appeals.html
+Link_4,testimonials.html
+Link_5,blog.html
+Link_6,contact.html
+Link_7,javascript:void(0)
+Link_8,version-2020/index.html
+Link_9,version-2016/index.html
+Link_10,version-2015/index.html
+Link_11,mailto:joe@law4veterans.com
+Language,en
+---,---
+File Path,./about.html
+Title,About Us - Law4Veterans
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,"width=device-width, initial-scale=1.0"
+Meta Robots,Not Found
+Canonical URL,Not Found
+h1_1,Law4Veterans
+h2_1,Our Commitment
+h3_1,Nationwide. Veterans. Lawyers.
+Link_1,index.html
+Link_2,about.html
+Link_3,appeals.html
+Link_4,testimonials.html
+Link_5,blog.html
+Link_6,contact.html
+Link_7,javascript:void(0)
+Link_8,version-2020/index.html
+Link_9,version-2016/index.html
+Link_10,version-2015/index.html
+Link_11,contact.html
+Language,en
+---,---
+File Path,./index.html
+Title,Law4Veterans
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,"width=device-width, initial-scale=1.0"
+Meta Robots,Not Found
+Canonical URL,Not Found
+h1_1,Law4Veterans
+h2_1,Have You Been Denied a VA Benefits Claim?
+h2_2,Have You Been Denied Veterans Disability Benefits?
+h2_3,Do You Feel like You’re Locked Out of Your Benefits?
+h2_4,Post Traumatic Stress Disorder (PTSD)
+h2_5,PACT ACT
+h2_6,Burn Pit Exposure
+h2_7,Military Sexual Trauma/Military Assault
+h2_8,Orthopedic Injuries
+h2_9,Chronic Diseases Acquired while in service
+h2_10,Vaccine Injuries
+h2_11,Toxic Chemical Exposure/Agent Orange/Radiation
+h3_1,What does it mean to have a presumptive condition for toxic exposure?
+h3_2,These cancers are now presumptive:
+h3_3,These illnesses are now presumptive:
+Link_1,index.html
+Link_2,about.html
+Link_3,appeals.html
+Link_4,testimonials.html
+Link_5,blog.html
+Link_6,contact.html
+Link_7,javascript:void(0)
+Link_8,version-2020/index.html
+Link_9,version-2016/index.html
+Link_10,version-2015/index.html
+Link_11,contact.html
+Link_12,testimonials.html
+Link_13,about.html
+Language,en
+---,---
+File Path,./blog.html
+Title,Blog - Law4Veterans
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,"width=device-width, initial-scale=1.0"
+Meta Robots,Not Found
+Canonical URL,Not Found
+h1_1,Law4Veterans
+h2_1,Blog
+h3_1,Board of Veteran’s Appeals
+Link_1,index.html
+Link_2,about.html
+Link_3,appeals.html
+Link_4,testimonials.html
+Link_5,blog.html
+Link_6,contact.html
+Link_7,javascript:void(0)
+Link_8,version-2020/index.html
+Link_9,version-2016/index.html
+Link_10,version-2015/index.html
+Link_11,#
+Language,en
+---,---
+File Path,./appeals.html
+Title,Help with Appeals - Law4Veterans
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,"width=device-width, initial-scale=1.0"
+Meta Robots,Not Found
+Canonical URL,Not Found
+h1_1,Law4Veterans
+h2_1,Help With Appeals
+h3_1,Help With Appeals
+Link_1,index.html
+Link_2,about.html
+Link_3,appeals.html
+Link_4,testimonials.html
+Link_5,blog.html
+Link_6,contact.html
+Link_7,javascript:void(0)
+Link_8,version-2020/index.html
+Link_9,version-2016/index.html
+Link_10,version-2015/index.html
+Language,en
+---,---
+File Path,./version-2020/index.html
+Title,Law4Veterans - 2020 Version
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,"width=device-width, initial-scale=1.0"
+Meta Robots,Not Found
+Canonical URL,Not Found
+h1_1,Have You Been Denied a VA Benefits Claim?
+h2_1,Have you been denied Veterans Disability Benefits?
+h2_2,Do you Feel Like You’re Locked Out of your benefits?
+h2_3,Call Today to Schedule your FREE Consultation
+h3_1,"Bochicchio & Pennebaker, PLLC"
+Link_1,#
+Link_2,#
+Link_3,#
+Link_4,#
+Link_5,#
+Link_6,#
+Link_7,#
+Link_8,#
+Link_9,#
+Language,en
+---,---
+File Path,./version-2020/scraped_content.html
+Title,Not Found
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,Not Found
+Meta Robots,Not Found
+Canonical URL,Not Found
+Language,Not Found
+---,---
+File Path,./version-2015/index.html
+Title,Law4Veterans - 2015 Version
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,"width=device-width, initial-scale=1.0"
+Meta Robots,Not Found
+Canonical URL,Not Found
+h1_1,DENIED VA BENEFITS?
+h2_1,"Joseph M Bochicchio, PLLC"
+h2_2,Denied Veterans Disability Benefits?
+h2_3,"Feel Like You're ""Locked Out"" of Your Benefits?"
+h3_1,Law 4 Veterans
+Link_1,#
+Link_2,#
+Link_3,#
+Link_4,#
+Language,en
+---,---
+File Path,./version-2015/scraped_content.html
+Title,Not Found
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,Not Found
+Meta Robots,Not Found
+Canonical URL,Not Found
+Language,Not Found
+---,---
+File Path,./version-2016/index.html
+Title,Law4Veterans - 2016 Version
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,"width=device-width, initial-scale=1.0"
+Meta Robots,Not Found
+Canonical URL,Not Found
+h2_1,Denied Benefits?
+h2_2,Locked Out of Benefits?
+h2_3,Contact Us TODAY!
+Image Alt_1,Law4Veterans Logo
+Link_1,#
+Link_2,#
+Link_3,#
+Link_4,#
+Link_5,#
+Link_6,#
+Link_7,#
+Language,en
+---,---
+File Path,./version-2016/scraped_content.html
+Title,Not Found
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,Not Found
+Meta Robots,Not Found
+Canonical URL,Not Found
+Language,Not Found
+---,---
+File Path,./scraped_content/20240820140802_index.html
+Title,Not Found
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,Not Found
+Meta Robots,Not Found
+Canonical URL,Not Found
+Language,Not Found
+---,---
+File Path,./scraped_content/20240820140802_blog.html
+Title,Not Found
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,Not Found
+Meta Robots,Not Found
+Canonical URL,Not Found
+Language,Not Found
+---,---
+File Path,./scraped_content/20240820140802_about-us.html
+Title,Not Found
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,Not Found
+Meta Robots,Not Found
+Canonical URL,Not Found
+Language,Not Found
+---,---
+File Path,./scraped_content/20240820140802_what-vets-say-about-us.html
+Title,Not Found
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,Not Found
+Meta Robots,Not Found
+Canonical URL,Not Found
+Language,Not Found
+---,---
+File Path,./scraped_content/20240820140802_help-with-appeals.html
+Title,Not Found
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,Not Found
+Meta Robots,Not Found
+Canonical URL,Not Found
+Language,Not Found
+---,---
+File Path,./scraped_content/20240820140802_contact-us.html
+Title,Not Found
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,Not Found
+Meta Robots,Not Found
+Canonical URL,Not Found
+Language,Not Found
+---,---

--- a/SEO/version-2015_seo.csv
+++ b/SEO/version-2015_seo.csv
@@ -1,0 +1,30 @@
+SEO_Element,Value
+File Path,version-2015/index.html
+Title,Law4Veterans - 2015 Version
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,"width=device-width, initial-scale=1.0"
+Meta Robots,Not Found
+Canonical URL,Not Found
+h1_1,DENIED VA BENEFITS?
+h2_1,"Joseph M Bochicchio, PLLC"
+h2_2,Denied Veterans Disability Benefits?
+h2_3,"Feel Like You're ""Locked Out"" of Your Benefits?"
+h3_1,Law 4 Veterans
+Link_1,#
+Link_2,#
+Link_3,#
+Link_4,#
+Language,en
+---,---
+File Path,version-2015/scraped_content.html
+Title,Not Found
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,Not Found
+Meta Robots,Not Found
+Canonical URL,Not Found
+Language,Not Found
+---,---

--- a/SEO/version-2016_seo.csv
+++ b/SEO/version-2016_seo.csv
@@ -1,0 +1,32 @@
+SEO_Element,Value
+File Path,version-2016/index.html
+Title,Law4Veterans - 2016 Version
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,"width=device-width, initial-scale=1.0"
+Meta Robots,Not Found
+Canonical URL,Not Found
+h2_1,Denied Benefits?
+h2_2,Locked Out of Benefits?
+h2_3,Contact Us TODAY!
+Image Alt_1,Law4Veterans Logo
+Link_1,#
+Link_2,#
+Link_3,#
+Link_4,#
+Link_5,#
+Link_6,#
+Link_7,#
+Language,en
+---,---
+File Path,version-2016/scraped_content.html
+Title,Not Found
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,Not Found
+Meta Robots,Not Found
+Canonical URL,Not Found
+Language,Not Found
+---,---

--- a/SEO/version-2020_seo.csv
+++ b/SEO/version-2020_seo.csv
@@ -1,0 +1,35 @@
+SEO_Element,Value
+File Path,version-2020/index.html
+Title,Law4Veterans - 2020 Version
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,"width=device-width, initial-scale=1.0"
+Meta Robots,Not Found
+Canonical URL,Not Found
+h1_1,Have You Been Denied a VA Benefits Claim?
+h2_1,Have you been denied Veterans Disability Benefits?
+h2_2,Do you Feel Like You’re Locked Out of your benefits?
+h2_3,Call Today to Schedule your FREE Consultation
+h3_1,"Bochicchio & Pennebaker, PLLC"
+Link_1,#
+Link_2,#
+Link_3,#
+Link_4,#
+Link_5,#
+Link_6,#
+Link_7,#
+Link_8,#
+Link_9,#
+Language,en
+---,---
+File Path,version-2020/scraped_content.html
+Title,Not Found
+Meta Description,Not Found
+Meta Keywords,Not Found
+Meta Author,Not Found
+Meta Viewport,Not Found
+Meta Robots,Not Found
+Canonical URL,Not Found
+Language,Not Found
+---,---

--- a/combine_csv.py
+++ b/combine_csv.py
@@ -1,0 +1,48 @@
+import os
+import csv
+
+def combine_reports():
+    """
+    Combines individual SEO CSV reports from the SEO/ directory into a single file.
+    """
+    seo_dir = 'SEO'
+    output_file = os.path.join(seo_dir, 'combined_seo_report.csv')
+
+    # Find all individual report CSVs, excluding the combined one if it exists
+    individual_reports = [f for f in os.listdir(seo_dir) if f.endswith('_seo.csv') and f != 'combined_seo_report.csv']
+
+    combined_data = []
+
+    for report_file in individual_reports:
+        # Derive the version name from the filename
+        version_name = report_file.replace('_seo.csv', '')
+        report_path = os.path.join(seo_dir, report_file)
+
+        try:
+            with open(report_path, 'r', encoding='utf-8') as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    # Add the version to the row
+                    new_row = {'Version': version_name, 'SEO_Element': row['SEO_Element'], 'Value': row['Value']}
+                    combined_data.append(new_row)
+        except Exception as e:
+            print(f"Could not process file {report_path}: {e}")
+
+    if not combined_data:
+        print("No data to combine.")
+        return
+
+    # Define the fieldnames for the combined CSV
+    fieldnames = ['Version', 'SEO_Element', 'Value']
+
+    try:
+        with open(output_file, 'w', newline='', encoding='utf-8') as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(combined_data)
+        print(f"Combined report saved to {output_file}")
+    except Exception as e:
+        print(f"Error writing to {output_file}: {e}")
+
+if __name__ == '__main__':
+    combine_reports()

--- a/scrape_seo.py
+++ b/scrape_seo.py
@@ -1,0 +1,110 @@
+import os
+import csv
+import argparse
+from bs4 import BeautifulSoup
+
+def scrape_seo_details(html_file_path):
+    """
+    Scrapes SEO details from a single HTML file.
+
+    Args:
+        html_file_path (str): The path to the HTML file.
+
+    Returns:
+        list: A list of dictionaries, where each dictionary represents a row in the CSV.
+    """
+    details = []
+    try:
+        with open(html_file_path, 'r', encoding='utf-8', errors='ignore') as f:
+            soup = BeautifulSoup(f, 'html.parser')
+
+        # File Path
+        details.append({'SEO_Element': 'File Path', 'Value': html_file_path})
+
+        # Title
+        title = soup.find('title')
+        details.append({'SEO_Element': 'Title', 'Value': title.get_text(strip=True) if title else 'Not Found'})
+
+        # Meta tags
+        meta_tags = {
+            'description': 'Meta Description',
+            'keywords': 'Meta Keywords',
+            'author': 'Meta Author',
+            'viewport': 'Meta Viewport',
+            'robots': 'Meta Robots'
+        }
+        for name, key in meta_tags.items():
+            tag = soup.find('meta', attrs={'name': name})
+            details.append({'SEO_Element': key, 'Value': tag['content'] if tag else 'Not Found'})
+
+        # Canonical URL
+        canonical = soup.find('link', attrs={'rel': 'canonical'})
+        details.append({'SEO_Element': 'Canonical URL', 'Value': canonical['href'] if canonical else 'Not Found'})
+
+        # Header tags
+        for i in range(1, 7):
+            headers = soup.find_all(f'h{i}')
+            for j, header in enumerate(headers):
+                details.append({'SEO_Element': f'h{i}_{j+1}', 'Value': header.get_text(strip=True)})
+
+        # Image Alt Texts
+        images = soup.find_all('img')
+        for i, img in enumerate(images):
+            alt_text = img.get('alt', 'Not Found')
+            details.append({'SEO_Element': f'Image Alt_{i+1}', 'Value': alt_text})
+
+        # Links
+        links = soup.find_all('a')
+        for i, link in enumerate(links):
+            href = link.get('href', 'Not Found')
+            details.append({'SEO_Element': f'Link_{i+1}', 'Value': href})
+
+        # Open Graph tags
+        og_tags = soup.find_all('meta', property=lambda x: x and x.startswith('og:'))
+        for tag in og_tags:
+            details.append({'SEO_Element': tag['property'], 'Value': tag['content']})
+
+        # Twitter Card tags
+        twitter_tags = soup.find_all('meta', attrs={'name': lambda x: x and x.startswith('twitter:')})
+        for tag in twitter_tags:
+            details.append({'SEO_Element': tag['name'], 'Value': tag['content']})
+
+        # Language
+        lang = soup.html.get('lang') if soup.html else 'Not Found'
+        details.append({'SEO_Element': 'Language', 'Value': lang if lang else 'Not Found'})
+
+    except Exception as e:
+        details.append({'SEO_Element': 'Error', 'Value': f"Could not process file {html_file_path}: {e}"})
+
+    return details
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Scrape SEO details from HTML files in a directory.')
+    parser.add_argument('directory', help='The directory to search for HTML files.')
+    parser.add_argument('output_file', help='The path to the output CSV file.')
+    args = parser.parse_args()
+
+    all_seo_details = []
+    for root, _, files in os.walk(args.directory):
+        for file in files:
+            if file.endswith('.html'):
+                file_path = os.path.join(root, file)
+                all_seo_details.extend(scrape_seo_details(file_path))
+                # Add a separator for clarity between files in the CSV
+                all_seo_details.append({'SEO_Element': '---', 'Value': '---'})
+
+    if not all_seo_details:
+        print("No HTML files found or no data extracted.")
+        return
+
+    with open(args.output_file, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=['SEO_Element', 'Value'])
+        writer.writeheader()
+        writer.writerows(all_seo_details)
+
+    print(f"SEO details saved to {args.output_file}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I have introduced a script to scrape SEO details from the various HTML versions of your website stored in the repository.

- I added `scrape_seo.py` to extract a comprehensive set of SEO data (titles, meta tags, headers, etc.) from your HTML files.
- I also added `combine_csv.py` to merge the individual version reports into a single, aggregated CSV file with a 'Version' column for clarity.
- The initial scraped data is now in the `SEO/` directory, with individual files for each site version and a combined report.

This provides you with a repeatable method for analyzing the SEO profile of your site across its different historical versions.